### PR TITLE
Docker connection configurable via cfg file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Proof of concept for simple image storage for docker.
 
 Currently, the user running dogestry needs permissions to access the docker socket. [See here for more info][docker-sudo]
 
-Currently the docker socket's location isn't configurable.
+The docker connection is local socket (`unix:///var/run/docker.sock`) as default. But is overridable configuring `connection` in `[docker]` entry in `dogestry.cfg`.
 
 ## usage
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -37,10 +37,20 @@ type DogestryCli struct {
 }
 
 
-func NewDogestryCli(client *client.Client, config config.Config) (*DogestryCli,error) {
+func NewDogestryCli(config config.Config) (*DogestryCli,error) {
+  dockerConnection := config.Docker.Connection
+  if dockerConnection == "" {
+    dockerConnection = "unix:///var/run/docker.sock"
+  }
+	newClient, err := client.NewClient(dockerConnection)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return &DogestryCli{
     Config: config,
-		client: *client,
+		client: *newClient,
 		err:    os.Stderr,
 	}, nil
 }
@@ -56,13 +66,13 @@ func (cli *DogestryCli) getMethod(name string) (func(...string) error, bool) {
 	return method.Interface().(func(...string) error), true
 }
 
-func ParseCommands(configFilePath string, client *client.Client, args ...string) error {
+func ParseCommands(configFilePath string, args ...string) error {
   config,err := parseConfig(configFilePath)
   if err != nil {
     return err
   }
 
-	cli,err := NewDogestryCli(client, config)
+	cli,err := NewDogestryCli(config)
   if err != nil {
     return err
   }

--- a/config/config.go
+++ b/config/config.go
@@ -17,10 +17,15 @@ type CompressorConfig struct {
   Lz4 string
 }
 
+type DockerConfig struct {
+  Connection string
+}
+
 type Config struct {
   Remote map[string]*RemoteConfig
   S3 S3Config
   Compressor CompressorConfig
+  Docker DockerConfig
 }
 
 

--- a/dogestry.eg.cfg
+++ b/dogestry.eg.cfg
@@ -4,3 +4,6 @@
 [s3]
   access-key-id=ididid
   secret-key=keykeykey
+
+[docker]
+  connection=http://docker-host:4243

--- a/main.go
+++ b/main.go
@@ -4,24 +4,16 @@ import (
 	"flag"
 	//"os"
 	"github.com/blake-education/dogestry/cli"
-	"github.com/blake-education/dogestry/client"
 	"log"
 )
-
-
-
 
 func main() {
   flConfigFile := flag.String("config", "", "the dogestry config file (defaults to 'dogestry.cfg' in the current directory)")
 	flag.Parse()
 
+  err := cli.ParseCommands(*flConfigFile, flag.Args()...)
 
-	client, err := client.NewClient("unix:///var/run/docker.sock")
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	if err = cli.ParseCommands(*flConfigFile, client, flag.Args()...); err != nil {
 		log.Println("err")
 		log.Fatal(err)
 	}


### PR DESCRIPTION
As developer I am using OSX, so I need to run docker in a VM. Dogestry needs to be configured to use the remote API through http not a local socket.

FYI: I am using https://github.com/noplay/docker-osx to wrap up the VM (vagrant) with the native docker client v0.7.3

I am not a Go developer, feel free to make any change and suggestions to my code.
